### PR TITLE
Fix basic auth handling for empty username

### DIFF
--- a/src/importers/curlRequestImporter.ts
+++ b/src/importers/curlRequestImporter.ts
@@ -82,7 +82,7 @@ export class CurlRequestImporter implements RequestTextImporter {
       } else if (tok === '-u' || tok === '--user') {
         const cred = tokens[++i] ?? '';
         const colonIdx = cred.indexOf(':');
-        if (colonIdx > 0) {
+        if (colonIdx >= 0) {
           basicAuth = {
             username: cred.substring(0, colonIdx),
             password: cred.substring(colonIdx + 1),

--- a/src/importers/httpRawRequestImporter.ts
+++ b/src/importers/httpRawRequestImporter.ts
@@ -136,7 +136,7 @@ export class HttpRawRequestImporter implements RequestTextImporter {
         try {
           const decoded = Buffer.from(val.substring(6).trim(), 'base64').toString('utf-8');
           const colonIdx = decoded.indexOf(':');
-          if (colonIdx > 0) {
+          if (colonIdx >= 0) {
             auth = {
               type: 'basic' as const,
               username: decoded.substring(0, colonIdx),


### PR DESCRIPTION
Adjust the logic to correctly handle basic authentication when the username is empty.