### PR TITLE
Fix Tab key in request body textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "missio",
   "displayName": "Missio REST Client",
   "description": "A lightweight, OpenCollection-compliant REST API client for VS Code. File-based collections, environments, and external secret providers.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "publisher": "missio",
   "license": "MIT",
   "repository": {

--- a/src/panels/basePanel.ts
+++ b/src/panels/basePanel.ts
@@ -111,12 +111,27 @@ export abstract class BaseEditorProvider implements vscode.CustomTextEditorProvi
 
     const sendVariables = () => this._sendVariables(webviewPanel.webview, document.uri.fsPath);
 
+    const sendIndentation = () => {
+      const config = vscode.workspace.getConfiguration('editor', document.uri);
+      webviewPanel.webview.postMessage({
+        type: 'indentation',
+        insertSpaces: config.get<boolean>('insertSpaces', true),
+        tabSize: config.get<number>('tabSize', 2),
+      });
+    };
+
     // Live-reload variables when collection or environment data changes
     disposables.push(
       this._collectionService.onDidChange(() => sendVariables()),
       this._environmentService.onDidChange(() => {
         this._secretService.clearSecretNamesCache();
         sendVariables();
+      }),
+      vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('editor.insertSpaces', document.uri) ||
+            e.affectsConfiguration('editor.tabSize', document.uri)) {
+          sendIndentation();
+        }
       }),
     );
 
@@ -126,6 +141,7 @@ export abstract class BaseEditorProvider implements vscode.CustomTextEditorProvi
         if (msg.type === 'ready') {
           this._sendDocumentToWebview(webviewPanel.webview, document);
           await sendVariables();
+          sendIndentation();
           return;
         }
         if (msg.type === 'getTokenStatus' || msg.type === 'getToken' || msg.type === 'deleteToken') {

--- a/src/webview/requestPanel.ts
+++ b/src/webview/requestPanel.ts
@@ -751,40 +751,45 @@ $('bodyData').addEventListener('scroll', syncScroll);
   });
 }
 
+// ── Body indent char (kept in sync with VS Code editor.insertSpaces / editor.tabSize) ──
+let _indentChar = '  ';
+
 // ── Autocomplete keyboard ────────────────────────
 $('bodyData').addEventListener('keydown', (e: Event) => {
   const ke = e as KeyboardEvent;
-  if (isAutocompleteActive()) { handleAutocompleteKeydown(ke); return; }
+  if (isAutocompleteActive() && handleAutocompleteKeydown(ke)) return;
   if (ke.key === 'Tab') {
     e.preventDefault();
     const ta = e.target as HTMLTextAreaElement;
     const start = ta.selectionStart;
     const end = ta.selectionEnd;
+    const indentLen = _indentChar.length;
     if (ke.shiftKey) {
       // Shift+Tab: outdent selected lines
       const val = ta.value;
       const lineStart = val.lastIndexOf('\n', start - 1) + 1;
       const lineEnd = end;
       const block = val.substring(lineStart, lineEnd);
-      const outdented = block.replace(/^  /gm, '');
+      const outdentRe = new RegExp('^' + _indentChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gm');
+      const outdented = block.replace(outdentRe, '');
       const removed = block.length - outdented.length;
       ta.value = val.substring(0, lineStart) + outdented + val.substring(lineEnd);
-      ta.selectionStart = Math.max(lineStart, start - (val.substring(lineStart, start).startsWith('  ') ? 2 : 0));
-      ta.selectionEnd = end - removed;
+      ta.selectionStart = Math.max(lineStart, start - (val.substring(lineStart, start).startsWith(_indentChar) ? indentLen : 0));
+      ta.selectionEnd = Math.max(ta.selectionStart, end - removed);
     } else if (start !== end) {
       // Tab with selection: indent all selected lines
       const val = ta.value;
       const lineStart = val.lastIndexOf('\n', start - 1) + 1;
       const block = val.substring(lineStart, end);
-      const indented = block.replace(/^/gm, '  ');
+      const indented = block.replace(/^/gm, _indentChar);
       const added = indented.length - block.length;
       ta.value = val.substring(0, lineStart) + indented + val.substring(end);
-      ta.selectionStart = start + 2;
+      ta.selectionStart = start + indentLen;
       ta.selectionEnd = end + added;
     } else {
-      // No selection: insert 2 spaces at cursor
-      ta.value = ta.value.substring(0, start) + '  ' + ta.value.substring(end);
-      ta.selectionStart = ta.selectionEnd = start + 2;
+      // No selection: insert indent at cursor
+      ta.value = ta.value.substring(0, start) + _indentChar + ta.value.substring(end);
+      ta.selectionStart = ta.selectionEnd = start + indentLen;
     }
     ta.dispatchEvent(new Event('input', { bubbles: true }));
   }
@@ -1337,6 +1342,9 @@ window.addEventListener('message', (event: MessageEvent) => {
       break;
     case 'promptCliApproval':
       showCliApprovalModal(msg.commandTemplate as string, msg.interpolatedCommand as string);
+      break;
+    case 'indentation':
+      _indentChar = msg.insertSpaces ? ' '.repeat(msg.tabSize) : '\t';
       break;
   }
 });

--- a/src/webview/requestPanel.ts
+++ b/src/webview/requestPanel.ts
@@ -753,7 +753,41 @@ $('bodyData').addEventListener('scroll', syncScroll);
 
 // ── Autocomplete keyboard ────────────────────────
 $('bodyData').addEventListener('keydown', (e: Event) => {
-  if (isAutocompleteActive()) handleAutocompleteKeydown(e as KeyboardEvent);
+  const ke = e as KeyboardEvent;
+  if (isAutocompleteActive()) { handleAutocompleteKeydown(ke); return; }
+  if (ke.key === 'Tab') {
+    e.preventDefault();
+    const ta = e.target as HTMLTextAreaElement;
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+    if (ke.shiftKey) {
+      // Shift+Tab: outdent selected lines
+      const val = ta.value;
+      const lineStart = val.lastIndexOf('\n', start - 1) + 1;
+      const lineEnd = end;
+      const block = val.substring(lineStart, lineEnd);
+      const outdented = block.replace(/^  /gm, '');
+      const removed = block.length - outdented.length;
+      ta.value = val.substring(0, lineStart) + outdented + val.substring(lineEnd);
+      ta.selectionStart = Math.max(lineStart, start - (val.substring(lineStart, start).startsWith('  ') ? 2 : 0));
+      ta.selectionEnd = end - removed;
+    } else if (start !== end) {
+      // Tab with selection: indent all selected lines
+      const val = ta.value;
+      const lineStart = val.lastIndexOf('\n', start - 1) + 1;
+      const block = val.substring(lineStart, end);
+      const indented = block.replace(/^/gm, '  ');
+      const added = indented.length - block.length;
+      ta.value = val.substring(0, lineStart) + indented + val.substring(end);
+      ta.selectionStart = start + 2;
+      ta.selectionEnd = end + added;
+    } else {
+      // No selection: insert 2 spaces at cursor
+      ta.value = ta.value.substring(0, start) + '  ' + ta.value.substring(end);
+      ta.selectionStart = ta.selectionEnd = start + 2;
+    }
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }
 });
 $('url').addEventListener('keydown', (e: Event) => {
   if (isAutocompleteActive()) {


### PR DESCRIPTION
## Summary
- Tab in the request body textarea was moving focus away instead of indenting the content
- Added Tab key handler: inserts 2 spaces at cursor, indents selected lines with Tab, outdents with Shift+Tab
- Autocomplete Tab behavior is preserved (handler returns early when autocomplete is active)

## Test plan
- [ ] Open a request, switch to Body tab, type some JSON
- [ ] Press Tab — should insert 2 spaces, not jump focus
- [ ] Select multiple lines, press Tab — all lines should indent
- [ ] Press Shift+Tab — selected lines should outdent
- [ ] Open autocomplete (type `{{`), press Tab — should accept suggestion, not indent