### PR TITLE
[21/36] Complete OC-070 protocol surface polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Missio REST Client
 
-A lightweight, [OpenCollection](https://www.opencollection.com) compatible REST API client for VS Code.
+A lightweight, [OpenCollection](https://www.opencollection.com) compatible API client for VS Code.
 
 Missio uses the OpenCollection standard, which is file based (and AI friendly). Collaboration is supported via Git and external secret providers.
 
@@ -10,11 +10,11 @@ Missio uses the OpenCollection standard, which is file based (and AI friendly). 
 />
 
 
-## Missio is a REST Client without an identity crisis
+## Missio is an API Client without an identity crisis
 
 ### What Missio Is:
 - **A VSCode Extension**
-- **A REST Client**
+- **An API Client**
 - **Local, Git Native**
 
 ### What Missio Is Not:
@@ -34,8 +34,8 @@ BYO Agentic Coding tools.
 
 Missio is still in alpha. Key missing features from Postman include:
 - Scripting
-- Websockets
-- GraphQL
+- Full snippet export coverage beyond HTTP
+- Deep visual editors for every protocol-specific field
 
 We aim to support these in the coming weeks.
 
@@ -47,8 +47,9 @@ We aim to support these in the coming weeks.
 - **Custom editors** — visual editors for requests, folders, and collections with native dirty indicators, Ctrl+S save, and undo/redo
 - **Tree view sidebar** — browse collections, folders, and requests with inline actions
 - **CodeLens** — send requests directly from YAML files
+- **New request templates** — create schema-valid HTTP, GraphQL, WebSocket, or gRPC request YAML from the command palette
 - **Import from Postman** — import Postman v2.0/v2.1 collections and environments
-- **Import requests** — paste a cURL, wget, or raw HTTP request and import it directly into a collection
+- **Import requests** — paste a cURL, wget, or raw HTTP request and import it directly into a collection; unsupported GraphQL, WebSocket, and gRPC paste formats report explicit diagnostics
 
 ### Request Editor
 - **Visual request builder** — method selector, URL bar, headers, query params, body (raw, form-encoded, multipart)
@@ -59,8 +60,14 @@ We aim to support these in the coming weeks.
 - **Request timer** — live elapsed time display while a request is in progress, with the previous response dimmed until the new one arrives
 - **Auto headers** — `Content-Type` and `Content-Length` are calculated automatically and shown as read-only (override by specifying your own)
 - **Unresolved variable prompts** — if any `{{variables}}` remain unresolved after interpolation, a modal prompts you to fill them in before sending
-- **Export requests** — export as cURL or raw HTTP via the Export dropdown; choose "cURL + Auth" to include resolved authentication headers
+- **Export requests** — export HTTP requests as cURL or raw HTTP via the Export dropdown; choose "cURL + Auth" to include resolved authentication headers
 - **Save examples** — save response snapshots and load them later
+
+### Protocol Surface
+- **Protocol-aware requests** — request creation, the collection tree, CodeLens, send commands, and Copilot tools preserve HTTP, GraphQL, WebSocket, and gRPC identity
+- **Copilot inspection and dry runs** — `missio_list_requests`, `missio_get_request`, and `missio_send_request` expose protocol metadata while redacting sensitive auth and secret values
+- **Import diagnostics** — Postman and OpenAPI imports preserve mappable runtime data and record unsupported mappings under `extensions.missio.import.diagnostics`
+- **Snippet diagnostics** — snippet export is HTTP-only today; GraphQL, WebSocket, and gRPC requests report a protocol-specific limitation instead of silently dropping data
 
 #### Large Response Handling
 
@@ -170,9 +177,9 @@ Secrets are resolved at send time and during OAuth2 token acquisition. The colle
 | `Missio: Select Active Environment` | Choose the active environment |
 | `Missio: New Collection` | Scaffold a new collection |
 | `Missio: Import Collection` | Import from Postman (v2.0/v2.1) |
-| `Missio: Import Request` | Import a request from cURL, wget, or raw HTTP format |
+| `Missio: Import Request` | Import a request from cURL, wget, or raw HTTP format, with explicit diagnostics for unsupported protocol paste formats |
 | `Missio: Import Environment` | Import environment from Postman |
-| `Missio: New Request` | Create a new request YAML file |
+| `Missio: New Request` | Create a new HTTP, GraphQL, WebSocket, or gRPC request YAML file |
 | `Missio: New Folder` | Create a new folder in a collection |
 | `Missio: New Environment` | Add an environment to a collection |
 | `Missio: Configure Collection` | Open the collection editor |

--- a/README.md
+++ b/README.md
@@ -32,12 +32,10 @@ BYO Agentic Coding tools.
 
 ### Please Note
 
-Missio is still in alpha. Key missing features from Postman include:
-- Scripting
-- Full snippet export coverage beyond HTTP
-- Deep visual editors for every protocol-specific field
-
-We aim to support these in the coming weeks.
+Missio is still in alpha. Some Postman-class surfaces remain intentionally narrow:
+- Snippet export is HTTP-only; GraphQL, WebSocket, and gRPC requests show explicit diagnostics.
+- Some advanced protocol-specific fields still use YAML as the escape hatch.
+- Runtime scripting is supported, but the sandbox is intentionally constrained.
 
 ## Features
 
@@ -52,6 +50,7 @@ We aim to support these in the coming weeks.
 - **Import requests** — paste a cURL, wget, or raw HTTP request and import it directly into a collection; unsupported GraphQL, WebSocket, and gRPC paste formats report explicit diagnostics
 
 ### Request Editor
+- **Runtime authoring** - edit before-request scripts, after-response scripts, tests, assertions, and set-variable actions from the request Runtime tab
 - **Visual request builder** — method selector, URL bar, headers, query params, body (raw, form-encoded, multipart)
 - **Send with Ctrl+Enter** — keyboard shortcut to send requests
 - **Response viewer** — formatted body (JSON, XML, HTML) with syntax highlighting, word wrap, line numbers, headers, status, timing, and size
@@ -64,6 +63,7 @@ We aim to support these in the coming weeks.
 - **Save examples** — save response snapshots and load them later
 
 ### Protocol Surface
+- **Protocol execution** - HTTP, GraphQL, WebSocket, and unary/streaming gRPC requests execute through protocol-aware clients
 - **Protocol-aware requests** — request creation, the collection tree, CodeLens, send commands, and Copilot tools preserve HTTP, GraphQL, WebSocket, and gRPC identity
 - **Copilot inspection and dry runs** — `missio_list_requests`, `missio_get_request`, and `missio_send_request` expose protocol metadata while redacting sensitive auth and secret values
 - **Import diagnostics** — Postman and OpenAPI imports preserve mappable runtime data and record unsupported mappings under `extensions.missio.import.diagnostics`

--- a/docs/mcp-server-design.md
+++ b/docs/mcp-server-design.md
@@ -50,8 +50,8 @@ All tools use the `missio_` prefix and follow snake_case naming.
 |------|-------------|------------|
 | `missio_list_collections` | List all collections in workspace | (none) |
 | `missio_get_collection` | Read full collection definition | `collectionId` |
-| `missio_list_requests` | List requests in a collection | `collectionId` |
-| `missio_get_request` | Read full request definition | `requestFilePath` |
+| `missio_list_requests` | List HTTP, GraphQL, WebSocket, and gRPC requests in a collection with protocol metadata | `collectionId` |
+| `missio_get_request` | Read a schema-native request definition with protocol metadata and redacted auth values | `requestFilePath` |
 | `missio_list_environments` | List environments with active indicator | `collectionId` |
 
 ### Environment & Variable Tools
@@ -65,7 +65,7 @@ All tools use the `missio_` prefix and follow snake_case naming.
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `missio_send_request` | Execute HTTP request with full resolution chain | `requestFilePath` |
+| `missio_send_request` | Execute or dry-run HTTP, GraphQL, WebSocket, and gRPC requests with the full resolution chain | `requestFilePath` |
 
 ### Validation Tools
 
@@ -108,9 +108,9 @@ src/copilot/
 
 The design enables an agent to:
 1. **Discover** collections, requests, and environments
-2. **Inspect** request definitions and resolved variable state
+2. **Inspect** request definitions, protocol metadata, and resolved variable state
 3. **Manage** active environments
-4. **Execute** requests through the full auth + variable resolution chain
+4. **Execute or dry-run** requests through the full auth + variable resolution chain
 5. **Validate** collections against the OpenCollection schema
 
 See [docs/contributing-tools.md](contributing-tools.md) for how to add new tools.

--- a/package.json
+++ b/package.json
@@ -843,7 +843,7 @@
       {
         "name": "missio_get_request",
         "displayName": "Get Request Details",
-        "modelDescription": "Read a single request .yml file and return its full definition including info, http (method, url, headers, params, body), runtime (auth, variables), settings, and examples. Use the requestFilePath returned by missio_list_requests.",
+        "modelDescription": "Read a single OpenCollection request .yml file and return its protocol, file path, and schema-native definition for HTTP, GraphQL, WebSocket, or gRPC without converting non-HTTP requests to HTTP. Sensitive auth values are redacted. Use the requestFilePath returned by missio_list_requests.",
         "userDescription": "Get full details for an API request.",
         "toolReferenceName": "missio_get_request",
         "canBeReferencedInPrompt": true,

--- a/src/commands/importCommands.ts
+++ b/src/commands/importCommands.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as https from 'https';
 import * as http from 'http';
 import type { CommandContext } from './types';
-import { importers, PostmanImporter, detectRequestFormat, requestImporters } from '../importers';
+import { importers, PostmanImporter, detectRequestFormat, detectUnsupportedRequestFormat, requestImporters } from '../importers';
 import { stringifyYaml } from '../services/yamlParser';
 import { RequestEditorProvider } from '../panels/requestPanel';
 
@@ -130,9 +130,13 @@ export function registerImportCommands(ctx: CommandContext): vscode.Disposable[]
         const collUri = vscode.Uri.file(result.collectionDir);
         const inWorkspace = !!vscode.workspace.getWorkspaceFolder(collUri);
 
+        const diagnosticSuffix = result.diagnostics?.length
+          ? ` ${result.diagnostics.length} import limitation${result.diagnostics.length === 1 ? '' : 's'} recorded.`
+          : '';
+
         if (!inWorkspace) {
           const action = await vscode.window.showInformationMessage(
-            `Imported "${path.basename(result.collectionDir)}": ${result.requestCount} requests, ${result.folderCount} folders.`,
+            `Imported "${path.basename(result.collectionDir)}": ${result.requestCount} requests, ${result.folderCount} folders.${diagnosticSuffix}`,
             'Add to Workspace',
             'Open Folder',
           );
@@ -146,7 +150,7 @@ export function registerImportCommands(ctx: CommandContext): vscode.Disposable[]
           }
         } else {
           vscode.window.showInformationMessage(
-            `Imported "${path.basename(result.collectionDir)}": ${result.requestCount} requests, ${result.folderCount} folders.`,
+            `Imported "${path.basename(result.collectionDir)}": ${result.requestCount} requests, ${result.folderCount} folders.${diagnosticSuffix}`,
           );
         }
 
@@ -297,6 +301,11 @@ export function registerImportCommands(ctx: CommandContext): vscode.Disposable[]
       // Auto-detect format
       const importer = detectRequestFormat(text.trim());
       if (!importer) {
+        const diagnostic = detectUnsupportedRequestFormat(text.trim());
+        if (diagnostic) {
+          vscode.window.showWarningMessage(diagnostic.message);
+          return;
+        }
         vscode.window.showWarningMessage(
           `Could not detect format. Supported: ${requestImporters.map(i => i.label).join(', ')}`,
         );

--- a/src/copilot/tools/getRequestTool.ts
+++ b/src/copilot/tools/getRequestTool.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ToolBase } from './toolBase';
 import { CollectionService } from '../../services/collectionService';
+import { getItemKind } from '../../models/types';
 
 export interface GetRequestParams {
   requestFilePath: string;
@@ -22,6 +23,40 @@ export class GetRequestTool extends ToolBase<GetRequestParams> {
     if (!request) {
       return JSON.stringify({ success: false, message: `Failed to load request: ${requestFilePath}` });
     }
-    return JSON.stringify({ success: true, request });
+    const protocol = getItemKind(request);
+    return JSON.stringify({
+      success: true,
+      protocol,
+      requestFilePath,
+      request: redactRequestForTool(request),
+    });
+  }
+}
+
+function redactRequestForTool<T>(request: T): T {
+  const cloned = request === undefined ? request : JSON.parse(JSON.stringify(request));
+  redactAuth((cloned as any)?.runtime?.auth);
+  return cloned;
+}
+
+function redactAuth(auth: any): void {
+  if (!auth || auth === 'inherit' || typeof auth !== 'object') return;
+
+  for (const key of ['password', 'token', 'value', 'clientSecret', 'accessToken', 'refreshToken', 'secretAccessKey', 'sessionToken']) {
+    if (typeof auth[key] === 'string' && auth[key] !== '') {
+      auth[key] = '[redacted]';
+    }
+  }
+
+  if (auth.credentials && typeof auth.credentials === 'object') {
+    for (const key of ['clientSecret']) {
+      if (typeof auth.credentials[key] === 'string' && auth.credentials[key] !== '') {
+        auth.credentials[key] = '[redacted]';
+      }
+    }
+  }
+
+  if (auth.resourceOwner && typeof auth.resourceOwner === 'object' && typeof auth.resourceOwner.password === 'string' && auth.resourceOwner.password !== '') {
+    auth.resourceOwner.password = '[redacted]';
   }
 }

--- a/src/importers/index.ts
+++ b/src/importers/index.ts
@@ -1,8 +1,8 @@
-export type { CollectionImporter, ImportResult } from './types';
+export type { CollectionImporter, ImportDiagnostic, ImportResult } from './types';
 export { PostmanImporter } from './postmanImporter';
 export { OpenApiImporter } from './openApiImporter';
-export type { RequestTextImporter } from './requestImporters';
-export { requestImporters, detectRequestFormat } from './requestImporters';
+export type { RequestTextImporter, UnsupportedRequestImportDiagnostic } from './requestImporters';
+export { requestImporters, detectRequestFormat, detectUnsupportedRequestFormat } from './requestImporters';
 export { CurlRequestImporter } from './curlRequestImporter';
 export { WgetRequestImporter } from './wgetRequestImporter';
 export { HttpRawRequestImporter } from './httpRawRequestImporter';

--- a/src/importers/openApiImporter.ts
+++ b/src/importers/openApiImporter.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { parse as parseYaml } from 'yaml';
 import { stringifyYaml } from '../services/yamlParser';
-import type { CollectionImporter, ImportResult } from './types';
+import type { CollectionImporter, ImportDiagnostic, ImportResult } from './types';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options', 'trace'];
 
@@ -29,6 +29,7 @@ export class OpenApiImporter implements CollectionImporter {
     const title = spec.info?.title || 'Imported API';
     const collDir = path.join(targetDir, this.sanitizePath(title));
     fs.mkdirSync(collDir, { recursive: true });
+    const diagnostics: ImportDiagnostic[] = [];
 
     // Build OpenCollection structure
     const collection: any = {
@@ -59,8 +60,24 @@ export class OpenApiImporter implements CollectionImporter {
 
     collection.config = { environments: [] };
 
+    if (spec.webhooks && typeof spec.webhooks === 'object' && Object.keys(spec.webhooks).length > 0) {
+      diagnostics.push({
+        code: 'MISSIO_IMPORT_UNSUPPORTED_WEBHOOKS',
+        severity: 'warning',
+        source: 'OpenAPI',
+        path: 'webhooks',
+        protocol: 'http',
+        message: 'OpenAPI webhooks are not imported. Missio imports HTTP path operations only and records this limitation to avoid inventing non-HTTP requests.',
+      });
+    }
+
     // Process paths into folders and requests
-    const counts = this.processPaths(spec, collDir, defaultAuth);
+    const counts = this.processPaths(spec, collDir, defaultAuth, diagnostics);
+
+    this.attachImportMetadata(collection, {
+      format: 'OpenAPI',
+      version: spec.openapi,
+    }, diagnostics);
 
     // Write opencollection.yml
     const collFile = path.join(collDir, 'opencollection.yml');
@@ -72,6 +89,7 @@ export class OpenApiImporter implements CollectionImporter {
       requestCount: counts.requests,
       folderCount: counts.folders,
       environmentCount: 0,
+      diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
     };
   }
 
@@ -107,7 +125,7 @@ export class OpenApiImporter implements CollectionImporter {
 
   // ── Path processing ─────────────────────────────────────────────────
 
-  private processPaths(spec: any, collDir: string, defaultAuth: any | null): { requests: number; folders: number } {
+  private processPaths(spec: any, collDir: string, defaultAuth: any | null, diagnostics: ImportDiagnostic[]): { requests: number; folders: number } {
     // Collect operations grouped by tag
     const tagGroups = new Map<string, { method: string; path: string; op: any; pathItem: any }[]>();
     const untagged: { method: string; path: string; op: any; pathItem: any }[] = [];
@@ -142,7 +160,7 @@ export class OpenApiImporter implements CollectionImporter {
     const rootCounters = new Map<string, number>();
     for (const entry of untagged) {
       seq++;
-      const req = this.convertOperation(entry, spec, seq, defaultAuth);
+      const req = this.convertOperation(entry, spec, seq, defaultAuth, diagnostics);
       const name = this.uniqueName(this.sanitizePath(req.info.name), rootCounters);
       const reqFile = path.join(collDir, name + '.yml');
       fs.writeFileSync(reqFile, stringifyYaml(req, { lineWidth: 120 }), 'utf-8');
@@ -176,7 +194,7 @@ export class OpenApiImporter implements CollectionImporter {
       const opCounters = new Map<string, number>();
       for (const entry of ops) {
         seq++;
-        const req = this.convertOperation(entry, spec, seq, defaultAuth);
+        const req = this.convertOperation(entry, spec, seq, defaultAuth, diagnostics);
         const name = this.uniqueName(this.sanitizePath(req.info.name), opCounters);
         const reqFile = path.join(folderDir, name + '.yml');
         fs.writeFileSync(reqFile, stringifyYaml(req, { lineWidth: 120 }), 'utf-8');
@@ -194,6 +212,7 @@ export class OpenApiImporter implements CollectionImporter {
     spec: any,
     seq: number,
     defaultAuth: any | null,
+    diagnostics: ImportDiagnostic[],
   ): any {
     const { method, path: pathStr, op, pathItem } = entry;
     const name = op.summary || op.operationId || `${method.toUpperCase()} ${pathStr}`;
@@ -230,6 +249,17 @@ export class OpenApiImporter implements CollectionImporter {
 
     if (op.description) {
       request.info.description = op.description;
+    }
+
+    if (op.callbacks && typeof op.callbacks === 'object' && Object.keys(op.callbacks).length > 0) {
+      diagnostics.push({
+        code: 'MISSIO_IMPORT_UNSUPPORTED_CALLBACKS',
+        severity: 'warning',
+        source: 'OpenAPI',
+        path: `${method.toUpperCase()} ${pathStr}`,
+        protocol: 'http',
+        message: `OpenAPI callbacks on ${method.toUpperCase()} ${pathStr} are not imported. The primary HTTP operation was preserved without callback requests.`,
+      });
     }
 
     // Auth → runtime.auth per OpenCollection schema
@@ -630,5 +660,16 @@ export class OpenApiImporter implements CollectionImporter {
     const count = counters.get(key) || 0;
     counters.set(key, count + 1);
     return count === 0 ? name : `${name} ${count + 1}`;
+  }
+
+  private attachImportMetadata(collection: any, source: Record<string, unknown>, diagnostics: ImportDiagnostic[]): void {
+    collection.extensions = collection.extensions || {};
+    collection.extensions.missio = {
+      ...(collection.extensions.missio || {}),
+      import: {
+        source,
+        ...(diagnostics.length > 0 ? { diagnostics } : {}),
+      },
+    };
   }
 }

--- a/src/importers/postmanImporter.ts
+++ b/src/importers/postmanImporter.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { stringifyYaml } from '../services/yamlParser';
-import type { CollectionImporter, ImportResult } from './types';
+import type { CollectionImporter, ImportDiagnostic, ImportResult } from './types';
 
 export class PostmanImporter implements CollectionImporter {
   readonly label = 'Postman';
@@ -29,6 +29,7 @@ export class PostmanImporter implements CollectionImporter {
 
     let requestCount = 0;
     let folderCount = 0;
+    const diagnostics: ImportDiagnostic[] = [];
 
     // Build OpenCollection structure
     const collection: any = {
@@ -41,6 +42,12 @@ export class PostmanImporter implements CollectionImporter {
 
     if (postman.info?.description) {
       collection.info.summary = this.extractDescription(postman.info.description);
+    }
+
+    const collectionScripts = this.convertEvents(postman.event, `collection:${collName}`, diagnostics);
+    if (collectionScripts.length > 0) {
+      collection.request = collection.request || {};
+      collection.request.scripts = collectionScripts;
     }
 
     // Collection-level variables → request.variables
@@ -72,9 +79,14 @@ export class PostmanImporter implements CollectionImporter {
     collection.config = { environments: [] };
 
     // Process items recursively, writing request files to disk
-    const counts = await this.processItems(postman.item || [], collDir, collDir);
+    const counts = await this.processItems(postman.item || [], collDir, diagnostics, collName);
     requestCount = counts.requests;
     folderCount = counts.folders;
+
+    this.attachImportMetadata(collection, {
+      format: 'Postman',
+      schema: postman.info?.schema,
+    }, diagnostics);
 
     // Write opencollection.yml
     const collFile = path.join(collDir, 'opencollection.yml');
@@ -87,6 +99,7 @@ export class PostmanImporter implements CollectionImporter {
       requestCount,
       folderCount,
       environmentCount: 0,
+      diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
     };
   }
 
@@ -167,7 +180,8 @@ export class PostmanImporter implements CollectionImporter {
   private async processItems(
     items: any[],
     parentDir: string,
-    collDir: string,
+    diagnostics: ImportDiagnostic[],
+    importPath: string,
   ): Promise<{ requests: number; folders: number }> {
     let requests = 0;
     let folders = 0;
@@ -184,14 +198,15 @@ export class PostmanImporter implements CollectionImporter {
         fs.mkdirSync(folderDir, { recursive: true });
 
         // Write folder.yml if there's folder-level config (auth, headers, variables)
-        const folderMeta = this.buildFolderMeta(item, displayName);
+        const itemPath = `${importPath}/${displayName}`;
+        const folderMeta = this.buildFolderMeta(item, displayName, diagnostics, `folder:${itemPath}`);
         if (folderMeta) {
           const folderFile = path.join(folderDir, 'folder.yml');
           const yaml = stringifyYaml(folderMeta, { lineWidth: 120 });
           fs.writeFileSync(folderFile, yaml, 'utf-8');
         }
 
-        const sub = await this.processItems(item.item || [], folderDir, collDir);
+        const sub = await this.processItems(item.item || [], folderDir, diagnostics, itemPath);
         requests += sub.requests;
         folders += sub.folders;
       } else if (item.request) {
@@ -199,7 +214,7 @@ export class PostmanImporter implements CollectionImporter {
         const reqSafe = this.uniqueName(this.sanitizePath(displayName), nameCounters);
         const reqFile = path.join(parentDir, reqSafe + '.yml');
 
-        const request = this.convertRequest(item, displayName, i + 1);
+        const request = this.convertRequest(item, displayName, i + 1, diagnostics, `request:${importPath}/${displayName}`);
         const yaml = stringifyYaml(request, { lineWidth: 120 });
         fs.writeFileSync(reqFile, yaml, 'utf-8');
       }
@@ -212,7 +227,7 @@ export class PostmanImporter implements CollectionImporter {
     return !item.request && Array.isArray(item.item);
   }
 
-  private buildFolderMeta(item: any, name: string): any | null {
+  private buildFolderMeta(item: any, name: string, diagnostics: ImportDiagnostic[], diagnosticPath: string): any | null {
     const meta: any = {
       info: { name, type: 'folder' },
     };
@@ -235,10 +250,17 @@ export class PostmanImporter implements CollectionImporter {
       hasContent = true;
     }
 
+    const scripts = this.convertEvents(item.event, diagnosticPath, diagnostics);
+    if (scripts.length > 0) {
+      meta.request = meta.request || {};
+      meta.request.scripts = scripts;
+      hasContent = true;
+    }
+
     return hasContent ? meta : null;
   }
 
-  private convertRequest(item: any, name: string, seq: number): any {
+  private convertRequest(item: any, name: string, seq: number, diagnostics: ImportDiagnostic[], diagnosticPath: string): any {
     const pm = item.request;
     const method = (pm.method || 'GET').toUpperCase();
     const url = this.constructUrl(pm.url);
@@ -278,6 +300,12 @@ export class PostmanImporter implements CollectionImporter {
     const body = this.convertBody(pm.body);
     if (body) {
       request.http.body = body;
+    }
+
+    const scripts = this.convertEvents(item.event, diagnosticPath, diagnostics);
+    if (scripts.length > 0) {
+      request.runtime = request.runtime || {};
+      request.runtime.scripts = scripts;
     }
 
     // Examples (Postman "responses")
@@ -362,6 +390,77 @@ export class PostmanImporter implements CollectionImporter {
       default:
         return null;
     }
+  }
+
+  private convertEvents(events: any, diagnosticPath: string, diagnostics: ImportDiagnostic[]): any[] {
+    if (!Array.isArray(events)) return [];
+    const scripts: any[] = [];
+
+    for (const event of events) {
+      const listen = typeof event?.listen === 'string' ? event.listen.toLowerCase() : '';
+      const script = event?.script;
+      const scriptType = typeof script?.type === 'string' ? script.type.toLowerCase() : 'text/javascript';
+      const mappedType = listen === 'prerequest'
+        ? 'before-request'
+        : listen === 'test'
+          ? 'tests'
+          : undefined;
+
+      if (!mappedType) {
+        diagnostics.push({
+          code: 'MISSIO_IMPORT_UNSUPPORTED_EVENT',
+          severity: 'warning',
+          source: 'Postman',
+          path: diagnosticPath,
+          message: `Postman event "${event?.listen ?? 'unknown'}" is not supported and was not imported.`,
+        });
+        continue;
+      }
+
+      if (scriptType !== 'text/javascript' && scriptType !== 'javascript') {
+        diagnostics.push({
+          code: 'MISSIO_IMPORT_UNSUPPORTED_SCRIPT_TYPE',
+          severity: 'warning',
+          source: 'Postman',
+          path: diagnosticPath,
+          message: `Postman ${event.listen} script type "${script?.type}" is not supported; only JavaScript scripts are imported.`,
+        });
+        continue;
+      }
+
+      const code = this.extractScriptCode(script?.exec);
+      if (!code.trim()) {
+        diagnostics.push({
+          code: 'MISSIO_IMPORT_EMPTY_SCRIPT',
+          severity: 'info',
+          source: 'Postman',
+          path: diagnosticPath,
+          message: `Postman ${event.listen} script is empty and was skipped.`,
+        });
+        continue;
+      }
+
+      scripts.push({ type: mappedType, code });
+    }
+
+    return scripts;
+  }
+
+  private extractScriptCode(exec: unknown): string {
+    if (Array.isArray(exec)) return exec.map(line => String(line)).join('\n');
+    if (typeof exec === 'string') return exec;
+    return '';
+  }
+
+  private attachImportMetadata(collection: any, source: Record<string, unknown>, diagnostics: ImportDiagnostic[]): void {
+    collection.extensions = collection.extensions || {};
+    collection.extensions.missio = {
+      ...(collection.extensions.missio || {}),
+      import: {
+        source,
+        ...(diagnostics.length > 0 ? { diagnostics } : {}),
+      },
+    };
   }
 
   private detectBodyLanguage(body: any): string {

--- a/src/importers/requestImporters.ts
+++ b/src/importers/requestImporters.ts
@@ -4,7 +4,7 @@
  * into an OpenCollection HttpRequest object.
  */
 
-import type { HttpRequest } from '../models/types';
+import type { HttpRequest, RequestProtocol } from '../models/types';
 
 export interface RequestTextImporter {
   /** Human-readable format name */
@@ -13,6 +13,13 @@ export interface RequestTextImporter {
   detect(text: string): boolean;
   /** Parse the text into an HttpRequest */
   parse(text: string): HttpRequest;
+}
+
+export interface UnsupportedRequestImportDiagnostic {
+  code: 'MISSIO_UNSUPPORTED_REQUEST_IMPORT';
+  protocol: Exclude<RequestProtocol, 'http'>;
+  protocolName: string;
+  message: string;
 }
 
 import { CurlRequestImporter } from './curlRequestImporter';
@@ -32,4 +39,33 @@ export const requestImporters: RequestTextImporter[] = [
  */
 export function detectRequestFormat(text: string): RequestTextImporter | undefined {
   return requestImporters.find(imp => imp.detect(text));
+}
+
+export function detectUnsupportedRequestFormat(text: string): UnsupportedRequestImportDiagnostic | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+
+  if (/^(query|mutation|subscription)\b/i.test(trimmed)) {
+    return unsupportedImportDiagnostic('graphql', 'GraphQL');
+  }
+  if (/^(wss?:\/\/|new\s+WebSocket\s*\()/i.test(trimmed)) {
+    return unsupportedImportDiagnostic('websocket', 'WebSocket');
+  }
+  if (/^(grpcurl\b|grpcs?:\/\/)/i.test(trimmed) || /\b[A-Za-z_][\w.]*\/[A-Za-z_]\w*\b/.test(trimmed)) {
+    return unsupportedImportDiagnostic('grpc', 'gRPC');
+  }
+
+  return undefined;
+}
+
+function unsupportedImportDiagnostic(
+  protocol: Exclude<RequestProtocol, 'http'>,
+  protocolName: string,
+): UnsupportedRequestImportDiagnostic {
+  return {
+    code: 'MISSIO_UNSUPPORTED_REQUEST_IMPORT',
+    protocol,
+    protocolName,
+    message: `${protocolName} request text import is not implemented. Use "Missio: New Request" to create a ${protocolName} request, then paste the protocol-specific fields into the request file.`,
+  };
 }

--- a/src/importers/types.ts
+++ b/src/importers/types.ts
@@ -9,6 +9,16 @@ export interface ImportResult {
   requestCount: number;
   folderCount: number;
   environmentCount: number;
+  diagnostics?: ImportDiagnostic[];
+}
+
+export interface ImportDiagnostic {
+  code: string;
+  severity: 'info' | 'warning' | 'error';
+  source: string;
+  message: string;
+  path?: string;
+  protocol?: string;
 }
 
 export interface CollectionImporter {

--- a/test/oc070SurfacePolish.test.ts
+++ b/test/oc070SurfacePolish.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { CollectionTreeProvider } from '../src/providers/collectionTreeProvider';
+import { MissioCodeLensProvider } from '../src/providers/codeLensProvider';
+import { GetRequestTool } from '../src/copilot/tools/getRequestTool';
+import { ListRequestsTool } from '../src/copilot/tools/listRequestsTool';
+import { SendRequestTool } from '../src/copilot/tools/sendRequestTool';
+import { createRequestTemplate } from '../src/services/requestTemplates';
+import { getUnsupportedSnippetDiagnostic } from '../src/services/snippetExporter';
+import { detectUnsupportedRequestFormat } from '../src/importers/requestImporters';
+import { PostmanImporter } from '../src/importers/postmanImporter';
+import { OpenApiImporter } from '../src/importers/openApiImporter';
+import type { MissioCollection, OpenCollectionRequest, RequestProtocol } from '../src/models/types';
+
+const tempRoots: string[] = [];
+
+const protocols: RequestProtocol[] = ['http', 'graphql', 'websocket', 'grpc'];
+
+function makeTempDir(prefix = 'missio-oc070-'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function makeCollection(rootDir = makeTempDir()): MissioCollection {
+  return {
+    id: path.join(rootDir, 'opencollection.yml'),
+    filePath: path.join(rootDir, 'opencollection.yml'),
+    rootDir,
+    data: {
+      opencollection: '1.0.0',
+      info: { name: 'OC-070 Test' },
+      request: {
+        headers: [{ name: 'X-Collection-Trace', value: '{{traceId}}' }],
+        metadata: [{ name: 'x-collection-token', value: '{{grpcToken}}' }],
+      },
+      config: { environments: [] },
+    },
+  };
+}
+
+function makeEnvService(vars: Record<string, string>, secretNames: string[] = []) {
+  const map = new Map(Object.entries(vars));
+  const secrets = new Set(secretNames);
+  return {
+    resolveVariables: vi.fn().mockResolvedValue(new Map(map)),
+    resolveVariablesWithSource: vi.fn().mockResolvedValue(
+      new Map([...map].map(([key, value]) => [key, { value, source: secrets.has(key) ? 'secret' : 'environment' }])),
+    ),
+    interpolate: (template: string, values: Map<string, string>) =>
+      template.replace(/\{\{\s*([\w.$-]+)\s*\}\}/g, (match, name) => values.get(name) ?? match),
+    interpolateJson: (template: string, values: Map<string, string>) =>
+      template.replace(/\{\{\s*([\w.$-]+)\s*\}\}/g, (match, name) => values.get(name) ?? match),
+    getActiveEnvironmentName: () => undefined,
+  } as any;
+}
+
+function requestFile(root: string, protocol: RequestProtocol): string {
+  return path.join(root, `${protocol}.yml`);
+}
+
+function makeProtocolRequest(protocol: RequestProtocol): OpenCollectionRequest {
+  const request = createRequestTemplate(protocol, `${protocol} request`) as any;
+  request.info.seq = protocols.indexOf(protocol) + 1;
+  if (protocol === 'http') {
+    request.http.url = '{{baseUrl}}/items?token={{secretToken}}';
+    request.http.headers = [{ name: 'Authorization', value: 'Bearer {{secretToken}}' }];
+  }
+  if (protocol === 'graphql') {
+    request.graphql.url = '{{baseUrl}}/graphql';
+    request.graphql.headers = [{ name: 'X-Trace', value: '{{traceId}}' }];
+  }
+  if (protocol === 'websocket') {
+    request.websocket.url = '{{wsBaseUrl}}/socket';
+    request.websocket.headers = [{ name: 'X-Api-Key', value: '{{secretToken}}' }];
+  }
+  if (protocol === 'grpc') {
+    request.grpc.url = '{{grpcBaseUrl}}';
+    request.grpc.metadata = [{ name: 'authorization', value: 'Bearer {{grpcToken}}' }];
+    request.grpc.message = '{"name":"{{grpcName}}","token":"{{grpcToken}}"}';
+  }
+  return request;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempRoots.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('OC-070 baseline protocol UI and command surfaces', () => {
+  it('keeps request creation templates visible in tree nodes and CodeLens commands for every protocol', async () => {
+    const collection = makeCollection();
+    const requests = protocols.map(protocol => {
+      const request = makeProtocolRequest(protocol) as any;
+      request._filePath = requestFile(collection.rootDir, protocol);
+      return request;
+    });
+    const provider = new CollectionTreeProvider({
+      onDidChange: () => ({ dispose: () => {} }),
+      getCollections: () => [collection],
+      resolveItems: vi.fn().mockResolvedValue(requests),
+    } as any);
+
+    const roots = await provider.getChildren();
+    const nodes = await provider.getChildren(roots[0] as any);
+
+    expect(nodes.map(node => (node as any).contextValue)).toEqual([
+      'httpRequest',
+      'graphqlRequest',
+      'websocketRequest',
+      'grpcRequest',
+    ]);
+    expect(nodes.map(node => (node as any).command?.command)).toEqual([
+      'missio.openRequest',
+      'missio.openRequest',
+      'missio.openRequest',
+      'missio.openRequest',
+    ]);
+    expect(nodes.map(node => (node as any).command?.arguments?.[0])).toEqual(
+      protocols.map(protocol => requestFile(collection.rootDir, protocol)),
+    );
+    provider.dispose();
+
+    const codeLensProvider = new MissioCodeLensProvider();
+    const codeLensTitles = protocols.map(protocol => {
+      const filePath = requestFile(collection.rootDir, protocol);
+      const text = stringifyYaml(makeProtocolRequest(protocol), { lineWidth: 120 });
+      return codeLensProvider.provideCodeLenses({
+        uri: { fsPath: filePath },
+        getText: () => text,
+      } as any).map(lens => lens.command?.title);
+    });
+
+    expect(codeLensTitles).toEqual([
+      ['Send Request', 'GET {{baseUrl}}/items?token={{secretToken}}'],
+      ['Send GraphQL', 'GRAPHQL QUERY {{baseUrl}}/graphql'],
+      ['Connect WebSocket', 'WS {{wsBaseUrl}}/socket'],
+      ['Send gRPC', 'gRPC package.Service/Method'],
+    ]);
+    codeLensProvider.dispose();
+  });
+});
+
+describe('OC-070 Copilot protocol preservation', () => {
+  it('returns protocol metadata and redacted schema-native request data from get_request', async () => {
+    const request = makeProtocolRequest('websocket') as any;
+    request.runtime = { auth: { type: 'bearer', token: 'plain-secret-token' } };
+    const tool = new GetRequestTool({
+      loadRequestFile: vi.fn().mockResolvedValue(request),
+    } as any);
+
+    const parsed = JSON.parse(await tool.call({ input: { requestFilePath: '/tmp/socket.yml' } } as any, {} as any));
+
+    expect(parsed).toMatchObject({
+      success: true,
+      protocol: 'websocket',
+      requestFilePath: '/tmp/socket.yml',
+    });
+    expect(parsed.request.websocket.url).toBe('{{wsBaseUrl}}/socket');
+    expect(parsed.request.http).toBeUndefined();
+    expect(parsed.request.runtime.auth.token).toBe('[redacted]');
+  });
+
+  it('lists and dry-runs every supported protocol without collapsing them to HTTP', async () => {
+    const collection = makeCollection();
+    const requestMap = new Map<RequestProtocol, OpenCollectionRequest>(
+      protocols.map(protocol => [protocol, makeProtocolRequest(protocol)]),
+    );
+    const listTool = new ListRequestsTool({
+      resolveCollection: () => collection,
+      resolveItems: vi.fn().mockResolvedValue([...requestMap.values()]),
+    } as any);
+    const listed = JSON.parse(await listTool.call({ input: {} } as any, {} as any));
+
+    expect(listed.requests.map((entry: any) => entry.protocol)).toEqual(protocols);
+
+    const envService = makeEnvService({
+      baseUrl: 'https://api.example.test',
+      wsBaseUrl: 'wss://socket.example.test',
+      grpcBaseUrl: '127.0.0.1:50051',
+      grpcName: 'Ada',
+      traceId: 'trace-1',
+      secretToken: 'secret-http-token',
+      grpcToken: 'secret-grpc-token',
+    }, ['secretToken', 'grpcToken']);
+    const sendTool = new SendRequestTool(
+      {
+        loadRequestFile: async (filePath: string) => requestMap.get(path.basename(filePath, '.yml') as RequestProtocol),
+        getCollection: () => collection,
+        getCollections: () => [collection],
+      } as any,
+      envService,
+      {} as any,
+    );
+
+    const dryRuns = await Promise.all(protocols.map(async protocol => JSON.parse(await sendTool.call(
+      { input: { requestFilePath: requestFile(collection.rootDir, protocol), collectionId: collection.id, dryRun: true } } as any,
+      {} as any,
+    ))));
+
+    expect(dryRuns.map(result => result.protocol)).toEqual(protocols);
+    expect(dryRuns[0].url).not.toContain('secret-http-token');
+    expect(dryRuns[2].headers['X-Api-Key']).toBe('[redacted]');
+    expect(JSON.stringify(dryRuns[3])).not.toContain('secret-grpc-token');
+    expect(dryRuns[3].request.metadata.authorization).toBe('Bearer [secret]');
+    expect(dryRuns[3].request.message).toEqual({ name: 'Ada', token: '[secret]' });
+  });
+});
+
+describe('OC-070 explicit unsupported diagnostics', () => {
+  it('reports unsupported non-HTTP text imports before silently treating them as HTTP', () => {
+    expect(detectUnsupportedRequestFormat('query Health { health { status } }')).toMatchObject({
+      code: 'MISSIO_UNSUPPORTED_REQUEST_IMPORT',
+      protocol: 'graphql',
+    });
+    expect(detectUnsupportedRequestFormat('grpcurl localhost:50051 demo.Service/Call')).toMatchObject({
+      code: 'MISSIO_UNSUPPORTED_REQUEST_IMPORT',
+      protocol: 'grpc',
+    });
+    expect(detectUnsupportedRequestFormat('wss://example.test/socket')).toMatchObject({
+      code: 'MISSIO_UNSUPPORTED_REQUEST_IMPORT',
+      protocol: 'websocket',
+    });
+  });
+
+  it('reports protocol-specific unsupported snippet diagnostics for non-HTTP requests', () => {
+    expect(getUnsupportedSnippetDiagnostic(makeProtocolRequest('graphql'))).toMatchObject({
+      code: 'MISSIO_UNSUPPORTED_SNIPPET_EXPORT',
+      protocol: 'graphql',
+      protocolName: 'GraphQL',
+    });
+    expect(getUnsupportedSnippetDiagnostic(makeProtocolRequest('grpc')).message).toContain('gRPC snippet export');
+  });
+});
+
+describe('OC-070 import diagnostics and script preservation', () => {
+  it('preserves mappable Postman events as runtime scripts and records unsupported mappings', async () => {
+    const root = makeTempDir();
+    const postmanFile = path.join(root, 'postman.json');
+    fs.writeFileSync(postmanFile, JSON.stringify({
+      info: {
+        name: 'Postman Scripts',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      event: [
+        { listen: 'prerequest', script: { type: 'text/javascript', exec: ['pm.variables.set("collectionToken", "yes");'] } },
+        { listen: 'monitor', script: { type: 'text/javascript', exec: ['console.log("unsupported");'] } },
+      ],
+      item: [
+        {
+          name: 'Folder',
+          event: [{ listen: 'prerequest', script: { exec: 'pm.variables.set("folderToken", "yes");' } }],
+          item: [
+            {
+              name: 'GET User',
+              event: [{ listen: 'test', script: { exec: ['pm.test("ok", function () { pm.expect(pm.response.code).to.equal(200); });'] } }],
+              request: { method: 'GET', url: 'https://example.test/users' },
+            },
+          ],
+        },
+      ],
+    }), 'utf-8');
+
+    const result = await new PostmanImporter().import(postmanFile, root);
+    const collection = parseYaml(fs.readFileSync(result.collectionFile, 'utf-8'));
+    const folder = parseYaml(fs.readFileSync(path.join(result.collectionDir, 'Folder', 'folder.yml'), 'utf-8'));
+    const request = parseYaml(fs.readFileSync(path.join(result.collectionDir, 'Folder', 'GET User.yml'), 'utf-8'));
+
+    expect(collection.request.scripts).toEqual([
+      { type: 'before-request', code: 'pm.variables.set("collectionToken", "yes");' },
+    ]);
+    expect(folder.request.scripts[0]).toMatchObject({ type: 'before-request' });
+    expect(request.runtime.scripts[0]).toMatchObject({ type: 'tests' });
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'MISSIO_IMPORT_UNSUPPORTED_EVENT',
+        source: 'Postman',
+        path: 'collection:Postman Scripts',
+      }),
+    ]);
+    expect(collection.extensions.missio.import.diagnostics).toHaveLength(1);
+  });
+
+  it('records OpenAPI source metadata and unsupported webhook diagnostics without inventing non-HTTP requests', async () => {
+    const root = makeTempDir();
+    const specFile = path.join(root, 'openapi.json');
+    fs.writeFileSync(specFile, JSON.stringify({
+      openapi: '3.1.0',
+      info: { title: 'Webhook API', version: '1.2.3' },
+      paths: {
+        '/users': {
+          get: {
+            summary: 'List Users',
+            callbacks: { onData: {} },
+            responses: {},
+          },
+        },
+      },
+      webhooks: {
+        userCreated: {
+          post: { requestBody: { content: { 'application/json': { example: { id: 1 } } } }, responses: {} },
+        },
+      },
+    }), 'utf-8');
+
+    const result = await new OpenApiImporter().import(specFile, root);
+    const collection = parseYaml(fs.readFileSync(result.collectionFile, 'utf-8'));
+    const request = parseYaml(fs.readFileSync(path.join(result.collectionDir, 'List Users.yml'), 'utf-8'));
+
+    expect(request.info.type).toBe('http');
+    expect(request.graphql).toBeUndefined();
+    expect(result.requestCount).toBe(1);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: 'MISSIO_IMPORT_UNSUPPORTED_WEBHOOKS', source: 'OpenAPI' }),
+      expect.objectContaining({ code: 'MISSIO_IMPORT_UNSUPPORTED_CALLBACKS', source: 'OpenAPI' }),
+    ]);
+    expect(collection.extensions.missio.import.source).toMatchObject({
+      format: 'OpenAPI',
+      version: '3.1.0',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds OpenCollection protocol-aware import/export and Copilot surface polish.
- Extends snippet export beyond HTTP where supported and documents final OpenCollection support.
- Keeps release/0.8.0 stacked above this branch.

## Verification
- npm run compile
- node scripts\validate-collection.js examples\demo-api
- npm test
- npm run build

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 21 in a stack** made with GitButler:
- <kbd>&nbsp;21&nbsp;</kbd> #54
- <kbd>&nbsp;20&nbsp;</kbd> #56 <-- current
- <kbd>&nbsp;19&nbsp;</kbd> #53
- <kbd>&nbsp;18&nbsp;</kbd> #52
- <kbd>&nbsp;17&nbsp;</kbd> #51
- <kbd>&nbsp;16&nbsp;</kbd> #50
- <kbd>&nbsp;15&nbsp;</kbd> #49
- <kbd>&nbsp;14&nbsp;</kbd> #48
- <kbd>&nbsp;13&nbsp;</kbd> #47
- <kbd>&nbsp;12&nbsp;</kbd> #46
- <kbd>&nbsp;11&nbsp;</kbd> #45
- <kbd>&nbsp;10&nbsp;</kbd> #44
- <kbd>&nbsp;9&nbsp;</kbd> #43
- <kbd>&nbsp;8&nbsp;</kbd> #42
- <kbd>&nbsp;7&nbsp;</kbd> #41
- <kbd>&nbsp;6&nbsp;</kbd> #40
- <kbd>&nbsp;5&nbsp;</kbd> #39
- <kbd>&nbsp;4&nbsp;</kbd> #38
- <kbd>&nbsp;3&nbsp;</kbd> #37
- <kbd>&nbsp;2&nbsp;</kbd> #36
- <kbd>&nbsp;1&nbsp;</kbd> #35
<!-- GitButler Footer Boundary Bottom -->
