### PR TITLE
[25/36] Add OC-130 protocol layout stability task

### DIFF
--- a/docs/open-collection-gap-analysis/AGENT_GOAL_PROMPTS.md
+++ b/docs/open-collection-gap-analysis/AGENT_GOAL_PROMPTS.md
@@ -76,6 +76,12 @@ If an agent host does not inject the project-local skills, tell the agent to rea
 /goal Complete OC-120 preview media zoom and rotate controls using $missio-agent-coordination and $missio-editor-schema-implementer without stopping until image and PDF response previews support a compact Ctrl+F-style media toolbar, zoom in/out, reset, fit behavior, rotate left/right, Ctrl+scroll zoom within the preview pane, safe PDF re-render/cancellation, AGENT_PROGRESS updates, packaged PDF.js asset verification, and complete automated transform, UI, wheel, reset, image/PDF, and build/package regression tests are implemented and passing.
 ```
 
+## Protocol Layout Stability
+
+```text
+/goal Complete OC-130 protocol-native request editor first paint using $missio-agent-coordination and $missio-editor-schema-implementer without stopping until opening HTTP, GraphQL, WebSocket, and gRPC requests renders a stable neutral or protocol-aware first-paint shell with no HTTP-default flash for non-HTTP requests, no stale HTTP controls during hydration, safe invalid-YAML fallback, AGENT_PROGRESS updates, and complete automated startup-state, protocol-render, layout-stability, round-trip, validation, and shared request editor regression tests are implemented and passing.
+```
+
 ## gRPC Streaming
 
 ```text
@@ -85,5 +91,5 @@ If an agent host does not inject the project-local skills, tell the agent to rea
 ## Final Integration
 
 ```text
-/goal Complete final OpenCollection compatibility integration across all Missio tracks using $missio-agent-coordination without stopping until all OC-000 through OC-120 task rows are Done, all GitButler branches or PRs are linked, the full test suite and required fixture integration tests pass, documentation is consistent, and AGENT_PROGRESS.md contains final verification evidence.
+/goal Complete final OpenCollection compatibility integration across all Missio tracks using $missio-agent-coordination without stopping until all OC-000 through OC-130 task rows are Done, all GitButler branches or PRs are linked, the full test suite and required fixture integration tests pass, documentation is consistent, and AGENT_PROGRESS.md contains final verification evidence.
 ```

--- a/docs/open-collection-gap-analysis/AGENT_PROGRESS.md
+++ b/docs/open-collection-gap-analysis/AGENT_PROGRESS.md
@@ -119,10 +119,10 @@ Record cross-cutting decisions here so parallel agents do not rediscover them.
   Next: launch OC-120 when ready; the agent should coordinate with the current response preview/PDF.js packaging work and request editor shell styles.
 
 - 2026-06-15 11:25 NZT - Codex Supervisor: Added OC-130 as a focused follow-up task for protocol-native request editor first paint and layout stability.
-  GitButler: planning update is on `supervisor/add-protocol-layout-stability-task`; existing uncommitted OC-120 claim in `AGENT_PROGRESS.md` was preserved and not overwritten.
+  GitButler: planning update is on `supervisor/add-protocol-layout-stability-task` commit `cd648cd`; existing uncommitted OC-120 claim in `AGENT_PROGRESS.md` was preserved and not overwritten.
   Coverage: documentation-only planning change; the task requires future automated startup-state, protocol-render, no-HTTP-flash, invalid-YAML fallback, layout-stability, round-trip, validation, and shared request editor regression tests.
   Changed: `docs/open-collection-gap-analysis/README.md`, `AGENT_GOAL_PROMPTS.md`, `AGENT_PROGRESS.md`, and `tasks/13-protocol-layout-stability.md`.
-  Verified: task references and goal prompt added; implementation tests not required for docs-only task creation.
+  Verified: `rg -n "OC-130|13-protocol-layout-stability|Protocol Layout Stability" docs\open-collection-gap-analysis` confirmed task references and goal prompt; implementation tests not required for docs-only task creation.
   Next: launch OC-130 after or alongside OC-120 only if the agent coordinates shared `requestPanel` CSS and webview startup surfaces.
 
 - 2026-06-15 00:57 NZT - Codex: Added OC-110 as a separate runtime authoring UX task after confirming snippet export belongs to OC-070 and non-HTTP runtime execution belongs to OC-080.

--- a/docs/open-collection-gap-analysis/AGENT_PROGRESS.md
+++ b/docs/open-collection-gap-analysis/AGENT_PROGRESS.md
@@ -20,7 +20,7 @@ Status values: `Unclaimed`, `Claimed`, `In Progress`, `Review Ready`, `Blocked`,
 
 | Role | Owner | Scope | Since | Current Focus |
 | --- | --- | --- | --- | --- |
-| Supervisor | Codex | Sanity-check completed tracks, run build/test/package/install verification, preserve GitButler branch hygiene, and append progress reports. | 2026-06-14 22:31 NZT | OC-000 through OC-110 accepted; OC-120 preview media controls queued as a focused follow-up task. |
+| Supervisor | Codex | Sanity-check completed tracks, run build/test/package/install verification, preserve GitButler branch hygiene, and append progress reports. | 2026-06-14 22:31 NZT | OC-000 through OC-110 accepted; OC-120 and OC-130 queued as focused follow-up UX tasks. |
 
 ## Test Coverage Rules
 
@@ -70,6 +70,7 @@ Use full branch names for stacking existing branches with `but move <child-branc
 | OC-100 | Request type UX | Done | Codex | feature/oc-100-request-type-ux (g0 after restack), stacked on supervisor/add-request-type-ux-task; implementation commit `5cb05a3` | Satisfied by `test/requestTypeUx.test.ts`: schema-valid HTTP/GraphQL/WebSocket/gRPC starter templates, actual `missio.newRequest` protocol picker/write/open flow, YAML and editor-model round-trip safety, no stale protocol roots, gRPC same-protocol editor guard, and read-only protocol chip shell. Shared regressions cover HTTP/GraphQL/WebSocket/gRPC editor, validation, command/tool, and protocol behavior. Switcher/conversion helpers are intentionally out of scope because the benchmarked tools emphasize protocol choice at creation and Postman locks saved request protocols. | `npx vitest run test/requestTypeUx.test.ts test/schemaRoundTrip.test.ts test/openCollectionFoundation.test.ts test/validationService.test.ts` passed 4 files/25 tests; targeted protocol suite passed 8 files/68 tests; `npm run compile` passed; `npm test` passed 21 files/405 tests; `node scripts/validate-collection.js examples/demo-api` passed 42/42 files; `npm run build` passed. | 2026-06-15 00:15 NZT | OC-100 complete; no saved-request switcher was added by product decision and benchmark alignment. Remaining unassigned changes are parallel OC-050/OC-090 work, not OC-100. |
 | OC-110 | Runtime authoring UX | Done | Codex | feature/oc-110-runtime-authoring-ux (g0), stacked on supervisor/add-runtime-authoring-ux-task; implementation commit `fe0ad14`; supervisor follow-up commit `1e6db05`; supervisor acceptance recorded | Satisfied by `test/runtimeAuthoringUx.test.ts`, `test/runtimeExecutionService.test.ts`, `test/validationService.test.ts`, and shared schema/protocol regressions: visual editor can author supported runtime scripts/tests/assertions/actions, no longer offers non-executing `hooks` scripts or unsupported persisted scopes for new rows, preserves schema-valid existing `hooks`/persisted-scope YAML with diagnostics, and runtime actions diagnose unsupported scopes instead of silently writing runtime variables. | `npm run compile` passed; focused `npx vitest run test/runtimeAuthoringUx.test.ts test/runtimeExecutionService.test.ts test/validationService.test.ts test/schemaRoundTrip.test.ts test/requestTypeUx.test.ts test/webSocketSupport.test.ts test/grpcSupport.test.ts` passed 7 files/69 tests; `node scripts\validate-collection.js examples\demo-api` passed 44/44 files; `npm test` passed 23 files/437 tests; `npm run build` passed. | 2026-06-15 09:51 NZT | Supervisor review accepted OC-110 rework; no remaining blocking findings. |
 | OC-120 | Preview media zoom and rotate controls | Unclaimed | TBD | TBD | Add automated coverage for media transform state, toolbar visibility, Ctrl+wheel zoom handling, image and PDF preview branches, reset behavior on new/non-media responses, stale PDF render cancellation, and build/package PDF.js asset inclusion. | Not started. | 2026-06-15 11:18 NZT | Claim with `missio-agent-coordination`; read `tasks/12-preview-media-controls.md`; create a focused branch before editing preview code. |
+| OC-130 | Protocol-native request editor first paint | Unclaimed | TBD | TBD | Add automated coverage for startup state, neutral/protocol-aware first paint, no HTTP-default flash for GraphQL/WebSocket/gRPC, invalid YAML fallback, layout stability, and shared request editor/protocol regressions. | Not started. | 2026-06-15 11:25 NZT | Claim with `missio-agent-coordination`; read `tasks/13-protocol-layout-stability.md`; create a focused branch before editing request panel code. |
 
 ## Dependency Map
 
@@ -88,6 +89,7 @@ Use full branch names for stacking existing branches with `but move <child-branc
 | OC-100 | OC-000 type guards, OC-010/OC-020/OC-030 protocol editor foundations; OC-050 if auth/template fields change | Request creation and visible type identity completeness |
 | OC-110 | OC-040 runtime schema/engine, OC-060 round-trip safety, OC-100 editor shell; coordinate with OC-070 and OC-080 | Visual authoring completeness for runtime scripts, tests, assertions, and actions |
 | OC-120 | Release PDF.js packaging fix, response preview rendering, request editor webview shell; coordinate with OC-100/OC-110 styles | Inspectable image/PDF response preview UX |
+| OC-130 | OC-100 protocol identity, request editor webview startup path, all protocol editor layouts; coordinate with OC-120 if shared CSS changes | Protocol-native editor first paint and layout stability |
 
 ## Shared Decisions
 
@@ -115,6 +117,13 @@ Record cross-cutting decisions here so parallel agents do not rediscover them.
   Changed: `docs/open-collection-gap-analysis/README.md`, `AGENT_GOAL_PROMPTS.md`, `AGENT_PROGRESS.md`, and `tasks/12-preview-media-controls.md`.
   Verified: task references and goal prompt added; implementation tests not required for docs-only task creation.
   Next: launch OC-120 when ready; the agent should coordinate with the current response preview/PDF.js packaging work and request editor shell styles.
+
+- 2026-06-15 11:25 NZT - Codex Supervisor: Added OC-130 as a focused follow-up task for protocol-native request editor first paint and layout stability.
+  GitButler: planning update is on `supervisor/add-protocol-layout-stability-task`; existing uncommitted OC-120 claim in `AGENT_PROGRESS.md` was preserved and not overwritten.
+  Coverage: documentation-only planning change; the task requires future automated startup-state, protocol-render, no-HTTP-flash, invalid-YAML fallback, layout-stability, round-trip, validation, and shared request editor regression tests.
+  Changed: `docs/open-collection-gap-analysis/README.md`, `AGENT_GOAL_PROMPTS.md`, `AGENT_PROGRESS.md`, and `tasks/13-protocol-layout-stability.md`.
+  Verified: task references and goal prompt added; implementation tests not required for docs-only task creation.
+  Next: launch OC-130 after or alongside OC-120 only if the agent coordinates shared `requestPanel` CSS and webview startup surfaces.
 
 - 2026-06-15 00:57 NZT - Codex: Added OC-110 as a separate runtime authoring UX task after confirming snippet export belongs to OC-070 and non-HTTP runtime execution belongs to OC-080.
   GitButler: planning update is on `supervisor/add-runtime-authoring-ux-task`, stacked on `supervisor/oc-050-090-100-audit`; active OC-070 implementation changes in `zz` were not edited or committed.

--- a/docs/open-collection-gap-analysis/README.md
+++ b/docs/open-collection-gap-analysis/README.md
@@ -69,6 +69,7 @@ If a scenario truly cannot be automated in this repo, document the reason, manua
 | OC-100 | Request Type UX | [10-request-type-ux.md](tasks/10-request-type-ux.md) | UI request type selection, read-only type visibility, and Bruno/Postman-aligned workflow review. |
 | OC-110 | Runtime Authoring UX | [11-runtime-authoring-ux.md](tasks/11-runtime-authoring-ux.md) | Visual editor authoring for scripts, tests, assertions, and set-variable actions. |
 | OC-120 | Preview Media Controls | [12-preview-media-controls.md](tasks/12-preview-media-controls.md) | Zoom, rotate, fit, reset, and Ctrl+scroll controls for image/PDF response previews. |
+| OC-130 | Protocol Layout Stability | [13-protocol-layout-stability.md](tasks/13-protocol-layout-stability.md) | Protocol-native first paint and layout stability when opening non-HTTP requests. |
 
 ## Project Skills
 
@@ -85,7 +86,7 @@ Project-local skills live in [.agents/skills/](../../.agents/skills/). They are 
 
 ## Final Compatibility Evidence
 
-OC-000 through OC-110 are implemented and tracked in [AGENT_PROGRESS.md](AGENT_PROGRESS.md). OC-120 is a new follow-up UX task for media preview controls. The table below records the main evidence surfaces that remain useful for maintenance and future audits.
+OC-000 through OC-110 are implemented and tracked in [AGENT_PROGRESS.md](AGENT_PROGRESS.md). OC-120 and OC-130 are follow-up UX tasks for media preview controls and protocol-native editor first paint. The table below records the main evidence surfaces that remain useful for maintenance and future audits.
 
 | Evidence Surface | Location |
 | --- | --- |

--- a/docs/open-collection-gap-analysis/tasks/13-protocol-layout-stability.md
+++ b/docs/open-collection-gap-analysis/tasks/13-protocol-layout-stability.md
@@ -1,0 +1,95 @@
+# OC-130 Protocol-Native Request Editor First Paint
+
+## Goal
+
+Make the request editor render protocol-native UI from its first visible paint. Opening a WebSocket, GraphQL, or gRPC request must not briefly show the HTTP layout before switching to the correct protocol.
+
+## Current Gap
+
+HTTP was historically the only first-class request type, and parts of the request editor still appear to initialize as HTTP before the real request document is loaded into the webview. With WebSocket, GraphQL, and gRPC now supported, that creates a visible layout disturbance and makes non-HTTP protocols feel bolted on rather than native.
+
+| Surface | Gap |
+| --- | --- |
+| Initial webview state | The editor appears to render an HTTP-shaped default layout before `requestLoaded` applies the actual protocol. |
+| Non-HTTP request open | WebSocket, GraphQL, and gRPC requests can visibly switch layout after opening. |
+| Loading state | There is no protocol-neutral or protocol-aware first-paint shell while the document is being parsed and sent. |
+| Layout stability | Header, URL, body, tabs, auth/runtime, and response areas can shift as protocol-specific controls appear or disappear. |
+| First-class protocol feel | The UI still implicitly treats HTTP as the default rather than one of several supported protocol modes. |
+
+## Implementation Plan
+
+1. Audit the request editor load path:
+
+| Area | Work |
+| --- | --- |
+| Extension host | Review `RequestEditorProvider._getHtml`, `_sendDocumentToWebview`, and `resolveCustomTextEditor` message ordering. |
+| Webview startup | Review `src/webview/requestPanel.ts` startup state, default model creation, `ready` handling, and `requestLoaded` rendering. |
+| Protocol render branches | Inspect HTTP, GraphQL, WebSocket, and gRPC layout activation paths for stale/default HTTP assumptions. |
+| CSS/layout | Review request editor CSS for controls that resize or appear late without reserved space. |
+
+2. Design the first-paint behavior:
+
+| Need | Expected Behavior |
+| --- | --- |
+| Neutral loading shell | Before request data is available, render a stable neutral shell or hidden editor body rather than an HTTP-specific request. |
+| Protocol-aware prehydration | If practical, parse enough document metadata in the extension host to pass the initial protocol into the generated HTML before scripts load. |
+| Direct protocol render | Once request data arrives, render the correct protocol layout directly without flashing through HTTP controls. |
+| Stable dimensions | Reserve predictable header, URL, tab, and body/response dimensions so mode changes do not cause avoidable layout jumps. |
+| No stale controls | HTTP-only controls, labels, body tabs, auth affordances, and method selectors must not appear while opening non-HTTP requests. |
+
+3. Make all protocols first-class:
+
+| Protocol | Expected First Visible Editor State |
+| --- | --- |
+| HTTP | HTTP method, URL, body/auth/runtime controls render normally. |
+| GraphQL | GraphQL query/variables/body controls render without an HTTP method flash. |
+| WebSocket | WebSocket connection/message controls render without HTTP body/auth controls flashing first. |
+| gRPC | gRPC method/proto/message controls render without HTTP method/body controls flashing first. |
+
+4. Preserve editor safety:
+
+| Requirement | Behavior |
+| --- | --- |
+| YAML source of truth | Startup improvements must not mutate request YAML or change save semantics. |
+| Invalid YAML | Invalid or incomplete YAML should show a stable loading/error/editor fallback without inventing an HTTP request. |
+| Existing request lifecycle | Dirty indicators, undo/redo, Ctrl+S, and no-op save behavior remain unchanged. |
+| Runtime/media panels | Runtime authoring, response rendering, and preview controls should not regress or compete with startup loading UI. |
+
+## Dependencies
+
+| Task | Impact |
+| --- | --- |
+| OC-000/OC-100 | Protocol type guards and request type identity should drive first-paint mode. |
+| OC-010/OC-020/OC-030/OC-090 | Protocol editor layouts must be treated as native targets, not delayed replacements for HTTP. |
+| OC-110 | Runtime authoring controls share the request editor shell and must remain stable during startup. |
+| OC-120 | Preview media controls touch response/preview UI; coordinate on shared request panel CSS and layout assumptions. |
+
+## Acceptance Criteria
+
+| Requirement | Acceptance |
+| --- | --- |
+| No HTTP flash | Opening GraphQL, WebSocket, or gRPC requests does not show HTTP-specific controls before the correct protocol layout appears. |
+| Stable first paint | The editor uses a neutral or protocol-aware loading state with stable dimensions while request data hydrates. |
+| Protocol parity | HTTP, GraphQL, WebSocket, and gRPC all have direct first visible layouts. |
+| Invalid YAML handling | Invalid YAML does not fall back to an HTTP-shaped editor by default. |
+| Regression safety | Existing request editing, save, round-trip, runtime authoring, and response preview behavior remains intact. |
+| Tests | Complete automated tests cover startup state, protocol-specific initial render, no HTTP-default fallback for non-HTTP requests, invalid YAML fallback, and shared editor regressions. |
+
+## Suggested Tests
+
+| Test | Expected Result |
+| --- | --- |
+| Initial HTML/source test. | The request panel startup state does not contain a hard-coded HTTP request model as the visible default. |
+| Protocol load render tests. | GraphQL, WebSocket, and gRPC `requestLoaded` messages render protocol-specific shells without first applying HTTP method/body state. |
+| Invalid YAML startup test. | Invalid document parse path leaves the editor in a neutral/loading/error-safe state, not an HTTP default. |
+| CSS/source regression test. | Startup/loading shell and protocol sections reserve stable dimensions and avoid overlapping controls on narrow layouts. |
+| Existing protocol editor tests. | Re-run request type UX, runtime authoring UX, GraphQL, WebSocket, gRPC, schema round-trip, and validation tests touched by shared request panel changes. |
+
+## Out Of Scope
+
+| Area | Reason |
+| --- | --- |
+| New protocol execution behavior | Covered by existing protocol/runtime tracks. |
+| Saved-request type switching | Product decision from OC-100 keeps saved request type identity read-only in the visual editor. |
+| Full visual regression harness | Add focused automated source/model tests now; create a follow-up only if deeper screenshot automation is needed. |
+| Response preview media controls | Covered by OC-120. |


### PR DESCRIPTION
## Summary
Adds the supervisor planning task for protocol-native first paint and layout stability across HTTP, GraphQL, WebSocket, and gRPC request editors.

## Stack
Base: supervisor/add-preview-zoom-rotate-task
Head: supervisor/add-protocol-layout-stability-task

## Validation
- 
pm run compile
- 
pm test
- 
pm run build
- Packaged missio-0.8.0.vsix
- Installed missio.missio@0.8.0 locally