### PR TITLE
[17/36] Add local build and install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 out/
 *.vsix
 .vscode-test/
+.socket/
 media/*.js
 media/*.css
 media/*.map

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,4 +17,5 @@ esbuild.js
 test/**
 docs/open-collection-gap-analysis/**
 vitest.config.ts
+scripts/build-and-install.ps1
 examples/demo-api/fixtures/*.key

--- a/package.json
+++ b/package.json
@@ -1127,6 +1127,7 @@
     "vscode:prepublish": "npm run build",
     "build:schema": "node schema/build-schema.js",
     "build": "npm run build:schema && node esbuild.js --production",
+    "install:local": "powershell -ExecutionPolicy Bypass -File scripts/build-and-install.ps1",
     "watch": "node esbuild.js --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-and-install.ps1
+++ b/scripts/build-and-install.ps1
@@ -1,0 +1,74 @@
+param(
+  [string]$OutputPath,
+  [string]$CodeCommand
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+  param(
+    [string]$Label,
+    [scriptblock]$Command
+  )
+
+  Write-Host ""
+  Write-Host "==> $Label"
+  & $Command
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE"
+  }
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Push-Location $repoRoot
+
+try {
+  if (-not (Test-Path -LiteralPath 'node_modules')) {
+    Invoke-Checked 'Install dependencies' { npm ci }
+  }
+
+  $packageJson = Get-Content -LiteralPath 'package.json' -Raw | ConvertFrom-Json
+  $version = [string]$packageJson.version
+
+  if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $env:TEMP "missio-$version-local.vsix"
+  }
+
+  $resolvedOutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
+  $outputDir = Split-Path -Parent $resolvedOutputPath
+  if (-not (Test-Path -LiteralPath $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+  }
+  if (Test-Path -LiteralPath $resolvedOutputPath) {
+    Remove-Item -LiteralPath $resolvedOutputPath -Force
+  }
+
+  if ([string]::IsNullOrWhiteSpace($CodeCommand)) {
+    $code = Get-Command code.cmd -ErrorAction SilentlyContinue
+    if (-not $code) {
+      $code = Get-Command code -ErrorAction SilentlyContinue
+    }
+    if (-not $code) {
+      throw 'Could not find VS Code CLI. Add code.cmd/code to PATH or pass -CodeCommand <path>.'
+    }
+    $CodeCommand = $code.Source
+  }
+
+  Invoke-Checked 'Package VSIX (runs npm run vscode:prepublish)' {
+    npx @vscode/vsce package --out $resolvedOutputPath
+  }
+
+  Invoke-Checked 'Install VSIX into VS Code' {
+    & $CodeCommand --install-extension $resolvedOutputPath --force
+  }
+
+  Write-Host ""
+  Write-Host "==> Installed extension"
+  & $CodeCommand --list-extensions --show-versions | Select-String -Pattern '^missio\.missio@'
+
+  Write-Host ""
+  Write-Host "VSIX: $resolvedOutputPath"
+} finally {
+  Pop-Location
+}

--- a/scripts/build-and-install.ps1
+++ b/scripts/build-and-install.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$OutputPath,
-  [string]$CodeCommand
+  [string]$CodeCommand,
+  [switch]$SkipNpmCi
 )
 
 $ErrorActionPreference = 'Stop'
@@ -24,7 +25,13 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 Push-Location $repoRoot
 
 try {
-  if (-not (Test-Path -LiteralPath 'node_modules')) {
+  if ($SkipNpmCi) {
+    if (-not (Test-Path -LiteralPath 'node_modules')) {
+      throw 'node_modules was not found. Run without -SkipNpmCi to install dependencies before packaging.'
+    }
+    Write-Host ""
+    Write-Host "==> Skipping dependency install"
+  } else {
     Invoke-Checked 'Install dependencies' { npm ci }
   }
 


### PR DESCRIPTION
﻿Stack PR for the Missio 0.8.0 OpenCollection review queue.

Verification run locally from the fully applied GitButler workspace:
- `npx vitest run test/grpcSupport.test.ts -t "gRPC demo server reliability"`
- `npx vitest run test/protocolLayoutStability.test.ts test/webSocketSupport.test.ts test/runtimeExecutionService.test.ts test/unresolvedVars.test.ts test/previewMediaControls.test.ts`
- `npm run compile`
- `node scripts/validate-collection.js examples/demo-api`
- `npm test`
- `npm run build`
- `npm run install:local`
