### PR TITLE
[23/36] Stabilize PDF asset line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Packaged PDF.js bundles are copied from node_modules and should not be EOL-normalized.
+media/pdf.min.mjs -text
+media/pdf.worker.min.mjs -text


### PR DESCRIPTION
﻿Stack PR for the Missio 0.8.0 OpenCollection review queue.

Verification run locally from the fully applied GitButler workspace:
- `npx vitest run test/grpcSupport.test.ts -t "gRPC demo server reliability"`
- `npx vitest run test/protocolLayoutStability.test.ts test/webSocketSupport.test.ts test/runtimeExecutionService.test.ts test/unresolvedVars.test.ts test/previewMediaControls.test.ts`
- `npm run compile`
- `node scripts/validate-collection.js examples/demo-api`
- `npm test`
- `npm run build`
- `npm run install:local`
