### PR TITLE
[34/36] Add OC-170 first-click action task

### DIFF
--- a/docs/open-collection-gap-analysis/AGENT_GOAL_PROMPTS.md
+++ b/docs/open-collection-gap-analysis/AGENT_GOAL_PROMPTS.md
@@ -106,8 +106,14 @@ If an agent host does not inject the project-local skills, tell the agent to rea
 /goal Complete OC-160 gRPC demo server reliability review using $missio-agent-coordination, $missio-protocol-implementer, and $missio-demo-server-fixtures without stopping until the current failing demo-request behavior is reproduced or concretely explained, every packaged gRPC demo request has a documented local start flow, localhost:50051 is served by a deterministic fixture or all request endpoints are corrected, unary/server-streaming/client-streaming/bidirectional-streaming/error/runtime demo requests pass live smoke tests through Missio execution where applicable, missing-fixture diagnostics are clear, AGENT_PROGRESS updates are complete, and demo collection validation plus complete automated gRPC/demo regression, build, package, and install verification are passing.
 ```
 
+## Request Action First-Click Reliability
+
+```text
+/goal Complete OC-170 request action first-click reliability using $missio-agent-coordination and $missio-editor-schema-implementer without stopping until the first-click ignored behavior after opening HTTP, GraphQL, WebSocket, and gRPC request editors is reproduced or concretely ruled out, Send/Connect/Disconnect/Send Message/CodeLens/toolbar actions are armed on first paint without requiring a focus priming click, hydration/focus/event-listener races are fixed, AGENT_PROGRESS updates are complete, and automated webview startup, action-click, protocol-layout, command, CodeLens, keyboard, accessibility, regression, build, package, and install verification are passing.
+```
+
 ## Final Integration
 
 ```text
-/goal Complete final OpenCollection compatibility integration across all Missio tracks using $missio-agent-coordination without stopping until all OC-000 through OC-160 task rows are Done, all GitButler branches or PRs are linked, the full test suite and required fixture integration tests pass, documentation is consistent, and AGENT_PROGRESS.md contains final verification evidence.
+/goal Complete final OpenCollection compatibility integration across all Missio tracks using $missio-agent-coordination without stopping until all OC-000 through OC-170 task rows are Done, all GitButler branches or PRs are linked, the full test suite and required fixture integration tests pass, documentation is consistent, and AGENT_PROGRESS.md contains final verification evidence.
 ```

--- a/docs/open-collection-gap-analysis/README.md
+++ b/docs/open-collection-gap-analysis/README.md
@@ -73,6 +73,7 @@ If a scenario truly cannot be automated in this repo, document the reason, manua
 | OC-140 | WebSocket Lifecycle UX | [14-websocket-lifecycle-ux.md](tasks/14-websocket-lifecycle-ux.md) | First-class connect, disconnect, send, status bar, CodeLens, and Copilot lifecycle management for WebSocket sessions. |
 | OC-150 | Runtime Assertion Variables And WebSocket Results UX | [15-runtime-assertion-variables.md](tasks/15-runtime-assertion-variables.md) | Variable-aware assertion fields, assertion interpolation, WebSocket runtime result visibility, and lifecycle button contrast. |
 | OC-160 | gRPC Demo Server Reliability | [16-grpc-demo-server-reliability.md](tasks/16-grpc-demo-server-reliability.md) | User-verifiable gRPC demo startup, localhost fixture reliability, and live smoke coverage. |
+| OC-170 | Request Action First-Click Reliability | [17-request-action-first-click.md](tasks/17-request-action-first-click.md) | Send, Connect, Disconnect, and related request actions fire on first click after opening a request. |
 
 ## Project Skills
 
@@ -89,13 +90,14 @@ Project-local skills live in [.agents/skills/](../../.agents/skills/). They are 
 
 ## Final Compatibility Evidence
 
-OC-000 through OC-150 are implemented and tracked in [AGENT_PROGRESS.md](AGENT_PROGRESS.md). OC-160 is a focused follow-up for gRPC demo server startup and live user-verification reliability. The table below records the main evidence surfaces that remain useful for maintenance and future audits.
+OC-000 through OC-150 are implemented and tracked in [AGENT_PROGRESS.md](AGENT_PROGRESS.md). OC-160 and OC-170 are focused follow-ups for gRPC demo reliability and first-click request action reliability. The table below records the main evidence surfaces that remain useful for maintenance and future audits.
 
 | Evidence Surface | Location |
 | --- | --- |
 | Request creation, starter templates, and visible request type identity. | [src/commands/requestCommands.ts](../../src/commands/requestCommands.ts), [src/services/requestTemplates.ts](../../src/services/requestTemplates.ts), [src/webview/requestPanel.ts](../../src/webview/requestPanel.ts) |
 | Import/export protocol diagnostics and snippet limitations. | [src/importers](../../src/importers), [src/services/snippetExporter.ts](../../src/services/snippetExporter.ts) |
 | Runtime scripting, tests, assertions, actions, and visual authoring. | [src/services/runtimeExecutionService.ts](../../src/services/runtimeExecutionService.ts), [src/webview/requestPanel.ts](../../src/webview/requestPanel.ts) |
+| Request editor action readiness, first-click behavior, and protocol action routing. | [src/panels/requestPanel.ts](../../src/panels/requestPanel.ts), [src/webview/requestPanel.ts](../../src/webview/requestPanel.ts), [src/commands/requestCommands.ts](../../src/commands/requestCommands.ts) |
 | Protocol execution for GraphQL, WebSocket, and gRPC unary/streaming requests. | [src/services/graphqlSupport.ts](../../src/services/graphqlSupport.ts), [src/services/webSocketClient.ts](../../src/services/webSocketClient.ts), [src/services/grpcClient.ts](../../src/services/grpcClient.ts) |
 | Local fixture API, demo requests, and collection validation. | [examples/demo-api](../../examples/demo-api), [scripts/validate-collection.js](../../scripts/validate-collection.js) |
 | gRPC demo startup and fixture smoke coverage. | [examples/demo-api/grpc-server.js](../../examples/demo-api/grpc-server.js), [examples/demo-api/gRPC](../../examples/demo-api/gRPC) |

--- a/docs/open-collection-gap-analysis/tasks/17-request-action-first-click.md
+++ b/docs/open-collection-gap-analysis/tasks/17-request-action-first-click.md
@@ -1,0 +1,80 @@
+# OC-170 Request Action First-Click Reliability
+
+## Goal
+
+Make every primary request action fire on the first user activation immediately after opening a request editor.
+
+Users should not need a priming click before Send, Connect, Disconnect, Send Message, or equivalent protocol actions work. If an action is not ready because the editor is still hydrating, the UI must show a clear disabled/loading state rather than accepting and silently dropping the first click.
+
+## Current Gap
+
+| Surface | Gap |
+| --- | --- |
+| Request editor startup | After opening a request, the first click on action buttons can be ignored outright. |
+| HTTP and GraphQL | Send must fire on the first click after open, reload, and protocol-aware hydration. |
+| WebSocket | Connect, Disconnect, and Send Message must be armed on first paint once visible and enabled. |
+| gRPC | Unary and streaming send actions must not require a focus or hydration priming click. |
+| Action routing | CodeLens, command palette, toolbar buttons, and Copilot-triggered actions should share a consistent ready-state contract. |
+| Tests | There is no explicit automated coverage proving first-click behavior immediately after editor open. |
+
+## Likely Causes To Investigate
+
+- VS Code webview focus activation swallowing the first pointer event.
+- Button handlers being attached after the buttons become visible.
+- Request hydration replacing DOM nodes after the first click target is rendered.
+- Disabled/loading attributes or CSS classes being cleared after the first user interaction.
+- Invisible overlays, first-paint shells, response panes, or pointer-event CSS blocking the initial click.
+- Debounced YAML/model updates racing with action dispatch and causing the action to no-op.
+- Duplicate handler registration or teardown during protocol layout transitions.
+
+## Scope
+
+1. Reproduce or concretely rule out the issue for HTTP, GraphQL, WebSocket, and gRPC requests.
+2. Audit request editor startup, hydration, action binding, ready state, and VS Code `postMessage` routing.
+3. Ensure visible enabled controls are armed before they can be clicked.
+4. Add deterministic tests that dispatch the first click immediately after initial render and after hydration.
+5. Cover mouse activation, keyboard activation where the control supports it, and command/CodeLens parity.
+6. Preserve protocol-native first-paint behavior from OC-130 and WebSocket lifecycle behavior from OC-140.
+7. Update the central progress ledger before and after implementation.
+
+## Implementation Guidance
+
+- Prefer stable event delegation from the earliest request webview script initialization point over attaching late per-button handlers.
+- Do not show enabled-looking controls before the request model, VS Code API bridge, action route, and protocol state are ready.
+- If an action is clicked while hydration is legitimately incomplete, either keep the control disabled or queue the action explicitly. Do not silently drop it.
+- Keep action dispatch single-shot. The fix must not create double sends, duplicate WebSocket connects, or repeated gRPC calls.
+- Use shared request editor helpers where possible so HTTP, GraphQL, WebSocket, and gRPC do not drift.
+- Keep Copilot tools and CodeLens behavior aligned with the same request action readiness rules.
+
+## Acceptance Criteria
+
+- The root cause is documented in `AGENT_PROGRESS.md`, or the issue is ruled out with concrete reproduction evidence and tests.
+- First click after opening a request sends exactly one action for HTTP Send, GraphQL Send, gRPC Send, WebSocket Connect, WebSocket Disconnect, and WebSocket Send Message where applicable.
+- Keyboard activation through Enter/Space works for the same visible controls where supported.
+- Visible enabled buttons are never in a state where they can accept a click but no-op due to missing handlers or stale request state.
+- Invalid YAML fallback, neutral/protocol first-paint shell, slow hydration, and reopen/reload flows are covered.
+- No duplicate sends/connects are introduced by repeated hydration or event-handler registration.
+- Request data posted by the first click uses the latest editor model/YAML and does not regress variable/runtime handling.
+- Automated tests cover the failure mode, the fix, and shared request editor regressions.
+- `npm run compile`, focused tests, `npm test`, `npm run build`, package, and local install verification pass before marking the task done.
+
+## Suggested Test Coverage
+
+- Add or extend request webview tests to render the initial shell, dispatch a click on each primary action as the first interaction, and assert exactly one message is posted.
+- Add hydration-transition tests proving first-click behavior before and after the request model is applied.
+- Extend protocol layout stability coverage for no stale HTTP controls, no blocked pointer events, and no duplicate handlers.
+- Extend WebSocket lifecycle tests for connect/disconnect/send-message first-click readiness and no duplicate session actions.
+- Extend gRPC and GraphQL editor/action tests as needed so protocol-specific send buttons are covered.
+- Add command and CodeLens regressions if the root cause touches shared action routing.
+
+Recommended verification:
+
+```powershell
+npm run compile
+npx vitest run test/protocolLayoutStability.test.ts test/webSocketSupport.test.ts test/requestTypeUx.test.ts test/graphqlSupport.test.ts test/grpcSupport.test.ts test/sendRequestTool.test.ts
+npm test
+npm run build
+npm run install:local
+```
+
+Package/install verification may use the project-local build/install script if that is the current supported flow.


### PR DESCRIPTION
﻿Stack PR for the Missio 0.8.0 OpenCollection review queue.

Verification run locally from the fully applied GitButler workspace:
- `npx vitest run test/grpcSupport.test.ts -t "gRPC demo server reliability"`
- `npx vitest run test/protocolLayoutStability.test.ts test/webSocketSupport.test.ts test/runtimeExecutionService.test.ts test/unresolvedVars.test.ts test/previewMediaControls.test.ts`
- `npm run compile`
- `node scripts/validate-collection.js examples/demo-api`
- `npm test`
- `npm run build`
- `npm run install:local`
